### PR TITLE
Scripts to turn existing instance into Slurm head node 

### DIFF
--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+
+#This script makes several assumptions:
+# 1. Running on a host with openstack client tools installed
+# 2. Using a default ssh key in ~/.ssh/
+# 3. The user knows what they're doing.
+# 4. Take some options: 
+#    openrc file 
+#    headnode size 
+#    cluster name 
+#    volume size
+
+show_help() {
+  echo "Options:
+        -n: HEADNODE_NAME: required, name of the cluster
+        -o: OPENRC_PATH: optional, path to a valid openrc file, default is ./openrc.sh
+        -s: HEADNODE_SIZE: optional, size of the headnode in Openstack flavor (default: m1.small)
+        -v: VOLUME_SIZE: optional, size of storage volume in GB, volume not created if 0
+        -d: DOCKER_ALLOW: optional flag, leave docker installed on headnode if set.
+	-j: JUPYTERHUB_BUILD: optional flag, install jupyterhub with SSL certs.
+  
+Usage: $0 -n [HEADNODE_NAME] -o [OPENRC_PATH] -v [VOLUME_SIZE] -s [HEADNODE_SIZE] [-d]"
+}
+
+OPTIND=1
+
+openrc_path="./openrc.sh"
+headnode_size="m1.small"
+headnode_name="noname"
+volume_size="0"
+install_opts=""
+
+while getopts ":jdhhelp:n:o:s:v:" opt; do
+  case ${opt} in
+    h|help|\?) show_help
+      exit 0
+      ;;
+    d) install_opts+="-d "
+      ;;
+    j) install_opts+="-j "
+      ;;
+    o) openrc_path=${OPTARG}
+      ;;
+    s) headnode_size=${OPTARG}
+      ;;
+    v) volume_size=${OPTARG}
+      ;;
+    n) headnode_name=${OPTARG}
+      ;;
+    :) echo "Option -$OPTARG requires an argument."
+      exit 1
+      ;;
+
+  esac
+done
+
+
+if [[ ! -f ${openrc_path} ]]; then
+  echo "openrc path: ${openrc_path} \n does not point to a file!"
+  exit 1
+fi
+
+#Move this to allow for error checking of OS conflicts
+source ${openrc_path}
+
+if [[ -z $( echo ${headnode_size} | grep -E '^m1|^m2|^g1|^g2' ) ]]; then
+  echo "Headnode size ${headnode_size} is not a valid JS instance size!"
+  exit 1
+elif [[ -n "$(echo ${volume_size} | tr -d [0-9])" ]]; then
+  echo "Volume size must be numeric only, in units of GB."
+  exit 1
+elif [[ ${headnode_name} == "noname" ]]; then
+  echo "No headnode name provided with -n, exiting!"
+  exit 1
+elif [[ -n $(openstack server list | grep -i ${headnode_name}) ]]; then
+  echo "Cluster name [${headnode_name}] conficts with existing Openstack entity!" 
+  exit 1
+elif [[ -n $(openstack volume list | grep -i ${headnode_name}-storage) ]]; then
+  echo "Volume name [${headnode_name}-storage] conficts with existing Openstack entity!" 
+  exit 1
+fi
+
+if [[ ! -e ${HOME}/.ssh/id_rsa.pub ]]; then
+#This may be temporary... but seems fairly reasonable.
+  echo "NO KEY FOUND IN ${HOME}/.ssh/id_rsa.pub! - please create one and re-run!"  
+  exit
+fi
+
+volume_name="${headnode_name}-storage"
+
+# Defining a function here to check for quotas, and exit if this script will cause problems!
+# also, storing 'quotas' in a global var, so we're not calling it every single time
+quotas=$(openstack quota show)
+quota_check () 
+{
+quota_name=$1
+type_name=$2 #the name for a quota and the name for the thing itself are not the same
+number_created=$3 #number of the thing that we'll create here.
+
+current_num=$(openstack ${type_name} list -f value | wc -l)
+
+max_types=$(echo "${quotas}" | awk -v quota=${quota_name} '$0 ~ quota {print $4}')
+
+#echo "checking quota for ${quota_name} of ${type_name} to create ${number_created} - want ${current_num} to be less than ${max_types}"
+
+if [[ "${current_num}" -lt "$((max_types + number_created))" ]]; then 
+  return 0
+fi
+return 1
+}
+
+
+quota_check "secgroups" "security group" 1
+quota_check "networks" "network" 1
+quota_check "subnets" "subnet" 1
+quota_check "routers" "router" 1
+quota_check "key-pairs" "keypair" 1
+quota_check "instances" "server" 1
+
+#These must match those defined in install.sh, slurm_resume.sh, compute_build_base_img.yml
+#  and compute_take_snapshot.sh, which ASSUME the headnode_name convention has not been deviated from.
+
+OS_PREFIX=${headnode_name}
+OS_NETWORK_NAME=${OS_PREFIX}-elastic-net
+OS_SUBNET_NAME=${OS_PREFIX}-elastic-subnet
+OS_ROUTER_NAME=${OS_PREFIX}-elastic-router
+OS_SSH_SECGROUP_NAME=${OS_PREFIX}-ssh-global
+OS_INTERNAL_SECGROUP_NAME=${OS_PREFIX}-internal
+OS_HTTP_S_SECGROUP_NAME=${OS_PREFIX}-http-s
+OS_KEYPAIR_NAME=${OS_USERNAME}-elastic-key
+OS_APP_CRED=${OS_PREFIX}-slurm-app-cred
+
+# This will allow for customization of the 1st 24 bits of the subnet range
+# The last 8 will be assumed open (netmask 255.255.255.0 or /24)
+# because going beyond that requires a general mechanism for translation from CIDR
+# to wildcard notation for ssh.cfg and compute_build_base_img.yml
+# which is assumed to be beyond the scope of this project.
+#  If there is a maintainable mechanism for this, of course, please let us know!
+SUBNET_PREFIX=10.0.0
+
+
+# Ensure that the correct private network/router/subnet exists
+if [[ -z "$(openstack network list | grep ${OS_NETWORK_NAME})" ]]; then
+  openstack network create ${OS_NETWORK_NAME}
+  openstack subnet create --network ${OS_NETWORK_NAME} --subnet-range ${SUBNET_PREFIX}.0/24 ${OS_SUBNET_NAME}
+fi
+##openstack subnet list
+if [[ -z "$(openstack router list | grep ${OS_ROUTER_NAME})" ]]; then
+  openstack router create ${OS_ROUTER_NAME}
+  openstack router add subnet ${OS_ROUTER_NAME} ${OS_SUBNET_NAME}
+  openstack router set --external-gateway public ${OS_ROUTER_NAME}
+fi
+
+security_groups=$(openstack security group list -f value)
+if [[ ! ("${security_groups}" =~ "${OS_SSH_SECGROUP_NAME}") ]]; then
+  openstack security group create --description "ssh \& icmp enabled" ${OS_SSH_SECGROUP_NAME}
+  openstack security group rule create --protocol tcp --dst-port 22:22 --remote-ip 0.0.0.0/0 ${OS_SSH_SECGROUP_NAME}
+  openstack security group rule create --protocol icmp ${OS_SSH_SECGROUP_NAME}
+fi
+if [[ ! ("${security_groups}" =~ "${OS_INTERNAL_SECGROUP_NAME}") ]]; then
+  openstack security group create --description "internal group for cluster" ${OS_INTERNAL_SECGROUP_NAME}
+  openstack security group rule create --protocol tcp --dst-port 1:65535 --remote-ip ${SUBNET_PREFIX}.0/24 ${OS_INTERNAL_SECGROUP_NAME}
+  openstack security group rule create --protocol icmp ${OS_INTERNAL_SECGROUP_NAME}
+fi
+if [[ (! ("${security_groups}" =~ "${OS_HTTP_S_SECGROUP_NAME}")) && "${install_opts}" =~ "j" ]]; then
+  openstack security group create --description "http/s for jupyterhub" ${OS_HTTP_S_SECGROUP_NAME}
+  openstack security group rule create --protocol tcp --dst-port 80 --remote-ip 0.0.0.0/0 ${OS_HTTP_S_SECGROUP_NAME}
+  openstack security group rule create --protocol tcp --dst-port 443 --remote-ip 0.0.0.0/0 ${OS_HTTP_S_SECGROUP_NAME}
+fi
+
+#Check if ${HOME}/.ssh/id_rsa.pub exists in JS
+if [[ -e ${HOME}/.ssh/id_rsa.pub ]]; then
+  home_key_fingerprint=$(ssh-keygen -l -E md5 -f ${HOME}/.ssh/id_rsa.pub | sed  's/.*MD5:\(\S*\) .*/\1/')
+fi
+openstack_keys=$(openstack keypair list -f value)
+
+home_key_in_OS=$(echo "${openstack_keys}" | awk -v mykey="${home_key_fingerprint}" '$2 ~ mykey {print $1}')
+
+if [[ -n "${home_key_in_OS}" ]]; then 
+	#RESET this to key that's already in OS
+  OS_KEYPAIR_NAME=${home_key_in_OS}
+elif [[ -n $(echo "${openstack_keys}" | grep ${OS_KEYPAIR_NAME}) ]]; then
+  openstack keypair delete ${OS_KEYPAIR_NAME}
+# This doesn't need to depend on the OS_PROJECT_NAME, as the slurm-key does, in install.sh and slurm_resume
+  openstack keypair create --public-key ${HOME}/.ssh/id_rsa.pub ${OS_KEYPAIR_NAME}
+else
+# This doesn't need to depend on the OS_PROJECT_NAME, as the slurm-key does, in install.sh and slurm_resume
+  openstack keypair create --public-key ${HOME}/.ssh/id_rsa.pub ${OS_KEYPAIR_NAME}
+fi
+
+#centos_base_image=$(openstack image list --status active | grep -iE "API-Featured-centos7-[[:alpha:]]{3,4}-[0-9]{2}-[0-9]{4}" | awk '{print $4}' | tail -n 1)
+centos_base_image="JS-API-Featured-CentOS8-Latest"
+
+#Now, generate an Openstack Application Credential for use on the cluster
+export $(openstack application credential create -f shell ${OS_APP_CRED} | sed 's/^\(.*\)/OS_ac_\1/')
+
+#Write it to a temporary file
+echo -e "export OS_AUTH_TYPE=v3applicationcredential
+export OS_AUTH_URL=${OS_AUTH_URL}
+export OS_IDENTITY_API_VERSION=3
+export OS_REGION_NAME="RegionOne"
+export OS_INTERFACE=public
+export OS_APPLICATION_CREDENTIAL_ID=${OS_ac_id}
+export OS_APPLICATION_CREDENTIAL_SECRET=${OS_ac_secret}" > ./openrc-app.sh
+
+#Function to generate file: sections for cloud-init config files
+# arguments are owner path permissions file_to_be_copied
+# All calls to this must come after an "echo "write_files:\n"
+generate_write_files () {
+#This is generating YAML, so... spaces are important.
+echo -e "  - encoding: b64\n    owner: $1\n    path: $2\n    permissions: $3\n    content: |\n$(cat $4 | base64 | sed 's/^/      /')"
+}
+
+user_data="$(cat ./prevent-updates.ci)\n"
+user_data+="$(echo -e "write_files:")\n"
+user_data+="$(generate_write_files "slurm" "/etc/slurm/openrc.sh" "0400" "./openrc-app.sh")\n"
+
+#Clean up!
+rm ./openrc-app.sh
+
+echo -e "openstack server create\
+        --user-data <(echo -e "${user_data}") \
+        --flavor ${headnode_size} \
+        --image ${centos_base_image} \
+        --key-name ${OS_KEYPAIR_NAME} \
+        --security-group ${OS_SSH_SECGROUP_NAME} \
+        --security-group ${OS_INTERNAL_SECGROUP_NAME} \
+        --nic net-id=${OS_NETWORK_NAME} \
+        ${headnode_name}"
+
+openstack server create \
+        --user-data <(echo -e "${user_data}") \
+        --flavor ${headnode_size} \
+        --image ${centos_base_image} \
+        --key-name ${OS_KEYPAIR_NAME} \
+        --security-group ${OS_SSH_SECGROUP_NAME} \
+        --security-group ${OS_INTERNAL_SECGROUP_NAME} \
+        --nic net-id=${OS_NETWORK_NAME} \
+        ${headnode_name}
+
+public_ip=$(openstack floating ip create public | awk '/floating_ip_address/ {print $4}')
+#For some reason there's a time issue here - adding a sleep command to allow network to become ready
+sleep 10
+openstack server add floating ip ${headnode_name} ${public_ip}
+
+hostname_test=$(ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no centos@${public_ip} 'hostname')
+echo "test1: ${hostname_test}"
+until [[ ${hostname_test} =~ "${headnode_name}" ]]; do
+  sleep 2
+  hostname_test=$(ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no centos@${public_ip} 'hostname')
+  echo "ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no centos@${public_ip} 'hostname'"
+  echo "test2: ${hostname_test}"
+done
+
+rsync -qa --exclude="openrc.sh" -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' ${PWD} centos@${public_ip}:
+
+if [[ "${volume_size}" != "0" ]]; then
+  echo "Creating volume ${volume_name} of ${volume_size} GB"
+  openstack volume create --size ${volume_size} ${volume_name}
+  openstack server add volume --device /dev/sdb ${headnode_name} ${volume_name}
+  sleep 5 # To fix a wait issue in volume creation
+  ssh -o StrictHostKeyChecking=no centos@${public_ip} 'sudo mkfs.xfs /dev/sdb && sudo mkdir -m 777 /export'
+  vol_uuid=$(ssh centos@${public_ip} 'sudo blkid /dev/sdb | sed "s|.*UUID=\"\(.\{36\}\)\" .*|\1|"')
+  echo "volume uuid is: ${vol_uuid}"
+  ssh centos@${public_ip} "echo -e \"UUID=${vol_uuid} /export                 xfs     defaults        0 0\" | sudo tee -a /etc/fstab && sudo mount -a"
+  echo "Volume sdb has UUID ${vol_uuid} on ${public_ip}"
+  if [[ ${docker_allow} == 1 ]]; then
+    ssh centos@${public_ip} "echo -E '{ \"data-root\": \"/export/docker\" }' | sudo tee -a /etc/docker/daemon.json && sudo systemctl restart docker"
+  fi
+
+fi
+
+if [[ "${install_opts}" =~ "-j" ]]; then
+  openstack server add security group ${headnode_name} ${OS_HTTP_S_SECGROUP_NAME}
+fi
+  
+echo "Copied over VC files, beginning Slurm installation and Compute Image configuration - should take 8-10 minutes."
+
+#Since PWD on localhost has the full path, we only want the current directory name
+ssh -o StrictHostKeyChecking=no centos@${public_ip} "cd ./${PWD##*/} && sudo ./install.sh ${install_opts}"
+
+echo "You should be able to login to your headnode with your Jetstream key: ${OS_KEYPAIR_NAME}, at ${public_ip}"
+
+if [[ ${install_opts} =~ "-j" ]]; then
+  echo "You will need to edit the file ${PWD}/install_jupyterhub.yml to reflect the public hostname of your new cluster, and use your email for SSL certs."
+  echo "Then, run the following command from the directory ${PWD} ON THE NEW HEADNODE to complete your jupyterhub setup:"
+  echo "sudo ansible-playbook -v --ssh-common-args='-o StrictHostKeyChecking=no' install_jupyterhub.yml"
+fi

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -66,9 +66,7 @@ elif [[ -n $(openstack volume list | grep -i ${headnode_name}-storage) ]]; then
 fi
 
 if [[ ! -e ${HOME}/.ssh/id_rsa.pub ]]; then
-#This may be temporary... but seems fairly reasonable.
-  echo "NO KEY FOUND IN ${HOME}/.ssh/id_rsa.pub! - please create one and re-run!"  
-  exit
+  ssh-keygen -q -N "" -f ${HOME}/.ssh/id_rsa
 fi
 
 volume_name="${headnode_name}-storage"

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -174,7 +174,7 @@ else
   openstack keypair create --public-key ${HOME}/.ssh/id_rsa.pub ${OS_KEYPAIR_NAME}
 fi
 
-SERVER_UUID=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq '.uuid')
+SERVER_UUID=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq '.uuid' | sed -e 's#"##g')
 
 echo -e "openstack server add network ${SERVER_UUID} ${OS_NETWORK_NAME}"
 openstack server add network ${SERVER_UUID} ${OS_NETWORK_NAME}

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -44,6 +44,8 @@ while getopts ":jdhhelp:n:o:s:v:" opt; do
   esac
 done
 
+sudo dnf -y install centos-release-openstack-train
+sudo dnf -y install python3-openstackclient
 
 if [[ ! -f ${openrc_path} ]]; then
   echo "openrc path: ${openrc_path} \n does not point to a file!"

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -221,7 +221,7 @@ sudo mkdir -p /etc/slurm
 sudo cp "${openrc_path}" /etc/slurm/openrc.sh
 sudo chmod 400 /etc/slurm/openrc.sh
 
-sudo ./install.sh ${install_opts}
+sudo ./install_local.sh ${install_opts}
 
 if [[ ${install_opts} =~ "-j" ]]; then
   echo "You will need to edit the file ${PWD}/install_jupyterhub.yml to reflect the public hostname of your new cluster, and use your email for SSL certs."

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -113,7 +113,7 @@ OS_ROUTER_NAME=${OS_PREFIX}-elastic-router
 OS_SSH_SECGROUP_NAME=${OS_PREFIX}-ssh-global
 OS_INTERNAL_SECGROUP_NAME=${OS_PREFIX}-internal
 OS_HTTP_S_SECGROUP_NAME=${OS_PREFIX}-http-s
-OS_KEYPAIR_NAME=${OS_USERNAME}-elastic-key
+OS_KEYPAIR_NAME=${OS_PREFIX}-elastic-key
 OS_APP_CRED=${OS_PREFIX}-slurm-app-cred
 
 # This will allow for customization of the 1st 24 bits of the subnet range

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -114,7 +114,6 @@ OS_SSH_SECGROUP_NAME=${OS_PREFIX}-ssh-global
 OS_INTERNAL_SECGROUP_NAME=${OS_PREFIX}-internal
 OS_HTTP_S_SECGROUP_NAME=${OS_PREFIX}-http-s
 OS_KEYPAIR_NAME=${OS_PREFIX}-elastic-key
-OS_APP_CRED=${OS_PREFIX}-slurm-app-cred
 
 # This will allow for customization of the 1st 24 bits of the subnet range
 # The last 8 will be assumed open (netmask 255.255.255.0 or /24)

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -185,7 +185,7 @@ openstack server add security group ${SERVER_UUID} ${OS_INTERNAL_SECGROUP_NAME}
 if [[ "${volume_size}" != "0" ]]; then
   echo "Creating volume ${volume_name} of ${volume_size} GB"
   openstack volume create --size ${volume_size} ${volume_name}
-  openstack server add volume --device /dev/sdb ${headnode_name} ${volume_name}
+  openstack server add volume --device /dev/sdb ${SERVER_UUID} ${volume_name}
   sleep 5 # To fix a wait issue in volume creation
   sudo mkfs.xfs /dev/sdb && sudo mkdir -m 777 /export
   vol_uuid=$(sudo blkid /dev/sdb | sed "s|.*UUID=\"\(.\{36\}\)\" .*|\1|")
@@ -199,7 +199,7 @@ if [[ "${volume_size}" != "0" ]]; then
 fi
 
 if [[ "${install_opts}" =~ "-j" ]]; then
-  openstack server add security group ${headnode_name} ${OS_HTTP_S_SECGROUP_NAME}
+  openstack server add security group ${SERVER_UUID} ${OS_HTTP_S_SECGROUP_NAME}
 fi
   
 echo "Beginning Slurm installation and Compute Image configuration - should take 8-10 minutes."

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -171,9 +171,6 @@ else
   openstack keypair create --public-key ${HOME}/.ssh/id_rsa.pub ${OS_KEYPAIR_NAME}
 fi
 
-sudo mkdir -p /etc/slurm
-sudo cp "${openrc_path}" /etc/slurm/openrc.sh
-
 SERVER_UUID=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq '.uuid')
 
 echo -e "openstack server add network ${SERVER_UUID} ${OS_NETWORK_NAME}"
@@ -223,8 +220,9 @@ fi
   
 echo "Copied over VC files, beginning Slurm installation and Compute Image configuration - should take 8-10 minutes."
 
-#Since PWD on localhost has the full path, we only want the current directory name
-ssh -o StrictHostKeyChecking=no centos@${public_ip} "cd ./${PWD##*/} && sudo ./install.sh ${install_opts}"
+sudo mkdir -p /etc/slurm
+sudo cp "${openrc_path}" /etc/slurm/openrc.sh
+sudo chmod 400 /etc/slurm/openrc.sh
 
 echo "You should be able to login to your headnode with your Jetstream key: ${OS_KEYPAIR_NAME}, at ${public_ip}"
 

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 set -x
 
 #This script makes several assumptions:

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -182,34 +182,18 @@ openstack server add security group ${SERVER_UUID} ${OS_SSH_SECGROUP_NAME}
 echo -e "openstack server add security group ${SERVER_UUID} ${OS_INTERNAL_SECGROUP_NAME}"
 openstack server add security group ${SERVER_UUID} ${OS_INTERNAL_SECGROUP_NAME}
 
-public_ip=$(openstack floating ip create public | awk '/floating_ip_address/ {print $4}')
-#For some reason there's a time issue here - adding a sleep command to allow network to become ready
-sleep 10
-openstack server add floating ip ${headnode_name} ${public_ip}
-
-hostname_test=$(ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no centos@${public_ip} 'hostname')
-echo "test1: ${hostname_test}"
-until [[ ${hostname_test} =~ "${headnode_name}" ]]; do
-  sleep 2
-  hostname_test=$(ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no centos@${public_ip} 'hostname')
-  echo "ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no centos@${public_ip} 'hostname'"
-  echo "test2: ${hostname_test}"
-done
-
-rsync -qa --exclude="openrc.sh" -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' ${PWD} centos@${public_ip}:
-
 if [[ "${volume_size}" != "0" ]]; then
   echo "Creating volume ${volume_name} of ${volume_size} GB"
   openstack volume create --size ${volume_size} ${volume_name}
   openstack server add volume --device /dev/sdb ${headnode_name} ${volume_name}
   sleep 5 # To fix a wait issue in volume creation
-  ssh -o StrictHostKeyChecking=no centos@${public_ip} 'sudo mkfs.xfs /dev/sdb && sudo mkdir -m 777 /export'
-  vol_uuid=$(ssh centos@${public_ip} 'sudo blkid /dev/sdb | sed "s|.*UUID=\"\(.\{36\}\)\" .*|\1|"')
+  sudo mkfs.xfs /dev/sdb && sudo mkdir -m 777 /export
+  vol_uuid=$(sudo blkid /dev/sdb | sed "s|.*UUID=\"\(.\{36\}\)\" .*|\1|")
   echo "volume uuid is: ${vol_uuid}"
-  ssh centos@${public_ip} "echo -e \"UUID=${vol_uuid} /export                 xfs     defaults        0 0\" | sudo tee -a /etc/fstab && sudo mount -a"
-  echo "Volume sdb has UUID ${vol_uuid} on ${public_ip}"
+  echo -e \"UUID=${vol_uuid} /export                 xfs     defaults        0 0\" | sudo tee -a /etc/fstab && sudo mount -a
+  echo "Volume sdb has UUID ${vol_uuid}"
   if [[ ${docker_allow} == 1 ]]; then
-    ssh centos@${public_ip} "echo -E '{ \"data-root\": \"/export/docker\" }' | sudo tee -a /etc/docker/daemon.json && sudo systemctl restart docker"
+    echo -E '{ \"data-root\": \"/export/docker\" }' | sudo tee -a /etc/docker/daemon.json && sudo systemctl restart docker
   fi
 
 fi
@@ -218,16 +202,16 @@ if [[ "${install_opts}" =~ "-j" ]]; then
   openstack server add security group ${headnode_name} ${OS_HTTP_S_SECGROUP_NAME}
 fi
   
-echo "Copied over VC files, beginning Slurm installation and Compute Image configuration - should take 8-10 minutes."
+echo "Beginning Slurm installation and Compute Image configuration - should take 8-10 minutes."
 
 sudo mkdir -p /etc/slurm
 sudo cp "${openrc_path}" /etc/slurm/openrc.sh
 sudo chmod 400 /etc/slurm/openrc.sh
 
-echo "You should be able to login to your headnode with your Jetstream key: ${OS_KEYPAIR_NAME}, at ${public_ip}"
+sudo ./install.sh ${install_opts}
 
 if [[ ${install_opts} =~ "-j" ]]; then
   echo "You will need to edit the file ${PWD}/install_jupyterhub.yml to reflect the public hostname of your new cluster, and use your email for SSL certs."
-  echo "Then, run the following command from the directory ${PWD} ON THE NEW HEADNODE to complete your jupyterhub setup:"
+  echo "Then, run the following command from the directory ${PWD} on this instance to complete your jupyterhub setup:"
   echo "sudo ansible-playbook -v --ssh-common-args='-o StrictHostKeyChecking=no' install_jupyterhub.yml"
 fi

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -57,7 +57,7 @@ headnode_name="$(hostname --short)"
 #Move this to allow for error checking of OS conflicts
 source ${openrc_path}
 
-elif [[ -n "$(echo ${volume_size} | tr -d [0-9])" ]]; then
+if [[ -n "$(echo ${volume_size} | tr -d [0-9])" ]]; then
   echo "Volume size must be numeric only, in units of GB."
   exit 1
 elif [[ -n $(openstack volume list | grep -i ${headnode_name}-storage) ]]; then

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -x
+# Uncomment below to help with debugging
+# set -x
 
 #This script makes several assumptions:
 # 1. Running on a host with openstack client tools installed

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -72,9 +72,6 @@ elif [[ -n "$(echo ${volume_size} | tr -d [0-9])" ]]; then
 elif [[ ${headnode_name} == "noname" ]]; then
   echo "No headnode name provided with -n, exiting!"
   exit 1
-elif [[ -n $(openstack server list | grep -i ${headnode_name}) ]]; then
-  echo "Cluster name [${headnode_name}] conficts with existing Openstack entity!" 
-  exit 1
 elif [[ -n $(openstack volume list | grep -i ${headnode_name}-storage) ]]; then
   echo "Volume name [${headnode_name}-storage] conficts with existing Openstack entity!" 
   exit 1

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -185,7 +185,8 @@ else
   openstack keypair create --public-key ${HOME}/.ssh/id_rsa.pub ${OS_KEYPAIR_NAME}
 fi
 
-cp "${openrc_path}" /etc/slurm/openrc.sh
+sudo mkdir -p /etc/slurm
+sudo cp "${openrc_path}" /etc/slurm/openrc.sh
 
 SERVER_UUID=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq '.uuid')
 

--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -x
+
 #This script makes several assumptions:
 # 1. Running on a host with openstack client tools installed
 # 2. Using a default ssh key in ~/.ssh/

--- a/cluster_destroy_local.sh
+++ b/cluster_destroy_local.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -x
-set -e
 
 #This script makes several assumptions:
 # 1. Running on a host with openstack client tools installed

--- a/cluster_destroy_local.sh
+++ b/cluster_destroy_local.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -x
+set -e
+
+#This script makes several assumptions:
+# 1. Running on a host with openstack client tools installed
+# 2. Using a default ssh key in ~/.ssh/
+# 3. The user knows what they're doing.
+# 4. Take some options: 
+#    openrc file 
+#    cluster name
+#    volume size
+
+show_help() {
+  echo "Options:
+        HEADNODE_NAME: required, name of the cluster to delete
+        OPENRC_PATH: optional, path to a valid openrc file, defaults to ~/openrc.sh
+        VOLUME_DELETE: optional flag, set to delete storage volumes, default false
+  
+Usage: $0 -n <HEADNODE_NAME> -o [OPENRC_PATH] [-v] "
+}
+
+OPTIND=1
+
+openrc_path="${HOME}/openrc.sh"
+headnode_name="$(hostname --short)"
+volume_delete="0"
+
+while getopts ":hhelp:o:n:v" opt; do
+  case ${opt} in
+    h|help|\?) show_help
+      exit 0
+      ;;
+    o) openrc_path=${OPTARG}
+      ;;
+    n) headnode_name=${OPTARG}
+      ;;
+    v) volume_delete=1
+      ;;
+    :) echo "Option -$OPTARG requires an argument."
+      exit 1
+      ;;
+
+  esac
+done
+
+
+if [[ ! -f ${openrc_path} ]]; then
+  echo "openrc path: ${openrc_path} \n does not point to a file!"
+  exit 1
+elif [[ "${volume_delete}" != "0" && "${volume_delete}" != "1" ]]; then
+  echo "Volume_delete parameter must be 0 or 1 instead of ${volume_delete}"
+  exit 1
+fi
+
+source ${openrc_path}
+
+#There's only one of each thing floating around, potentially some compute instances that weren't cleaned up and some images... SO!
+OS_PREFIX=${headnode_name}
+OS_SSH_SECGROUP_NAME=${OS_PREFIX}-ssh-global
+OS_INTERNAL_SECGROUP_NAME=${OS_PREFIX}-internal
+OS_SLURM_KEYPAIR=${OS_PREFIX}-slurm-key
+OS_ROUTER_NAME=${OS_PREFIX}-elastic-router
+OS_SUBNET_NAME=${OS_PREFIX}-elastic-subnet
+OS_NETWORK_NAME=${OS_PREFIX}-elastic-net
+
+compute_nodes=$(openstack server list -f value -c Name | grep -E "compute-${headnode_name}-base-instance|${headnode_name}-compute" )
+if [[ -n "${compute_nodes}" ]]; then
+for node in "${compute_nodes}"
+do
+	echo "Deleting compute node: ${node}"
+  openstack server delete ${node}
+done
+fi
+
+sleep 5 # seems like there are issues with the network deleting correctly 
+
+SERVER_UUID=$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq '.uuid' | sed -e 's#"##g')
+
+openstack server remove security group ${SERVER_UUID} ${OS_SSH_SECGROUP_NAME} || true
+openstack server remove security group ${SERVER_UUID} ${OS_INTERNAL_SECGROUP_NAME} || true
+openstack server remove network ${SERVER_UUID} ${OS_NETWORK_NAME}
+
+openstack security group delete ${OS_SSH_SECGROUP_NAME}
+openstack security group delete ${OS_INTERNAL_SECGROUP_NAME}
+openstack keypair delete ${OS_SLURM_KEYPAIR} # We don't delete the elastic-key, since it could be a user's key used for other stuff
+openstack router unset --external-gateway ${OS_ROUTER_NAME}
+openstack router remove subnet ${OS_ROUTER_NAME} ${OS_SUBNET_NAME}
+openstack router delete ${OS_ROUTER_NAME}
+openstack subnet delete ${OS_SUBNET_NAME}
+openstack network delete ${OS_NETWORK_NAME}
+
+headnode_images=$(openstack image list --private -f value -c Name | grep ${headnode_name}-compute-image- )
+for image in "${headnode_images}"
+do
+  openstack image delete ${image}
+done

--- a/cluster_destroy_local.sh
+++ b/cluster_destroy_local.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -x
+# Uncomment below to help with debugging
+# set -x
 
 #This script makes several assumptions:
 # 1. Running on a host with openstack client tools installed

--- a/cluster_destroy_local.sh
+++ b/cluster_destroy_local.sh
@@ -60,6 +60,7 @@ OS_PREFIX=${headnode_name}
 OS_SSH_SECGROUP_NAME=${OS_PREFIX}-ssh-global
 OS_INTERNAL_SECGROUP_NAME=${OS_PREFIX}-internal
 OS_SLURM_KEYPAIR=${OS_PREFIX}-slurm-key
+OS_KEYPAIR_NAME=${OS_PREFIX}-elastic-key
 OS_ROUTER_NAME=${OS_PREFIX}-elastic-router
 OS_SUBNET_NAME=${OS_PREFIX}-elastic-subnet
 OS_NETWORK_NAME=${OS_PREFIX}-elastic-net
@@ -83,7 +84,9 @@ openstack server remove network ${SERVER_UUID} ${OS_NETWORK_NAME}
 
 openstack security group delete ${OS_SSH_SECGROUP_NAME}
 openstack security group delete ${OS_INTERNAL_SECGROUP_NAME}
-openstack keypair delete ${OS_SLURM_KEYPAIR} # We don't delete the elastic-key, since it could be a user's key used for other stuff
+openstack keypair delete ${OS_SLURM_KEYPAIR}
+# We DO delete the elastic-key, since we created it from scratch before
+openstack keypair delete ${OS_KEYPAIR_NAME}
 openstack router unset --external-gateway ${OS_ROUTER_NAME}
 openstack router remove subnet ${OS_ROUTER_NAME} ${OS_SUBNET_NAME}
 openstack router delete ${OS_ROUTER_NAME}

--- a/compute_take_snapshot.sh
+++ b/compute_take_snapshot.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 source /etc/slurm/openrc.sh
 
 compute_image="$(hostname -s)-compute-image-latest"

--- a/compute_take_snapshot.sh
+++ b/compute_take_snapshot.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 source /etc/slurm/openrc.sh
 
 compute_image="$(hostname -s)-compute-image-latest"

--- a/install.sh
+++ b/install.sh
@@ -222,7 +222,7 @@ cat /etc/passwd | awk -F':' '$4 >= 1001 && $4 < 65000 {print "useradd -M -u", $3
 # build instance for compute base image generation, take snapshot, and destroy it
 echo "Creating compute image! based on $centos_base_image"
 
-ansible-playbook -vvvv --ssh-common-args='-o StrictHostKeyChecking=no' compute_build_base_img.yml
+ansible-playbook -v --ssh-common-args='-o StrictHostKeyChecking=no' compute_build_base_img.yml
 
 #to allow other users to run ansible!
 rm -r /tmp/.ansible

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 OPTIND=1
 
 docker_allow=0 #default to NOT installing docker; must be 0 or 1
@@ -222,7 +224,7 @@ cat /etc/passwd | awk -F':' '$4 >= 1001 && $4 < 65000 {print "useradd -M -u", $3
 # build instance for compute base image generation, take snapshot, and destroy it
 echo "Creating compute image! based on $centos_base_image"
 
-ansible-playbook -v --ssh-common-args='-o StrictHostKeyChecking=no' compute_build_base_img.yml
+ansible-playbook -vvvv --ssh-common-args='-o StrictHostKeyChecking=no' compute_build_base_img.yml
 
 #to allow other users to run ansible!
 rm -r /tmp/.ansible

--- a/install_local.sh
+++ b/install_local.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -x
+# Uncomment below to help with debugging
+# set -x
 
 OPTIND=1
 

--- a/install_local.sh
+++ b/install_local.sh
@@ -38,8 +38,9 @@ OS_SLURM_KEYPAIR=${OS_PREFIX}-slurm-key
 SUBNET_PREFIX=10.0.0
 
 #Open the firewall on the internal network for Cent8
-firewall-cmd --permanent --add-rich-rule="rule source address="${SUBNET_PREFIX}.0/24" family='ipv4' accept"
-firewall-cmd --add-rich-rule="rule source address="${SUBNET_PREFIX}.0/24" family='ipv4' accept"
+# TODO: Re-enable?
+#firewall-cmd --permanent --add-rich-rule="rule source address="${SUBNET_PREFIX}.0/24" family='ipv4' accept"
+#firewall-cmd --add-rich-rule="rule source address="${SUBNET_PREFIX}.0/24" family='ipv4' accept"
 
 dnf -y install http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm \
        centos-release-openstack-train

--- a/install_local.sh
+++ b/install_local.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 OPTIND=1
 
 docker_allow=0 #default to NOT installing docker; must be 0 or 1

--- a/install_local.sh
+++ b/install_local.sh
@@ -227,7 +227,7 @@ cat /etc/passwd | awk -F':' '$4 >= 1001 && $4 < 65000 {print "useradd -M -u", $3
 # build instance for compute base image generation, take snapshot, and destroy it
 echo "Creating compute image! based on $centos_base_image"
 
-ansible-playbook -vvvv --ssh-common-args='-o StrictHostKeyChecking=no' compute_build_base_img.yml
+ansible-playbook -v --ssh-common-args='-o StrictHostKeyChecking=no' compute_build_base_img.yml
 
 #to allow other users to run ansible!
 rm -r /tmp/.ansible


### PR DESCRIPTION
## Background

Jetstream2 will provide push-button clusters. [Exosphere](https://gitlab.com/exosphere/exosphere) is one of the supported graphical user interfaces for Jetstream2. Exosphere is a 'pure client' application - this means that it requires no persistent services to interact with the OpenStack API. Currently the scripts in this repository will only work when executed on a computer/server that has the OpenStack command-line tools installed. This presents a problem for a tool like Exosphere, since the instance orchestration logic for Exosphere runs entirely in the browser. See the following issue on the Exosphere repository: https://gitlab.com/exosphere/exosphere/-/issues/636

The Exosphere developers considered the following three options:

> A. Exosphere could do all this directly with the OpenStack API using the Exosphere orchestration engine  
> B. Exosphere could create a throw-away instance which runs `cluster_create.sh` to create the head node, and then deletes the throw-away instance  
> C. We could create a modified version of the `cluster_create.sh` script which runs on the head node itself, after it's been created by Exosphere  

We decided to implement option C, with help from XSEDE Cyberinfrastructure Resource Integration staff. This pull request contains the resulting modifications in order to launch elastic Slurm clusters using Exosphere.

## Some notable changes

- New scripts called `cluster_create_local.sh` & `install_local.sh` (based on `cluster_create.sh` & `install.sh`) to run on an existing OpenStack instance, and will configure this instance as the head node of a new Slurm cluster
- A new script called `cluster_destroy_local.sh` (based on `cluster_destroy.sh`) to run on an existing OpenStack server/Slurm head node, and will clean up any OpenStack resources created by the `cluster_create_local.sh` script (including the head node itself - optional, and disabled by default)
- By default both `cluster_create_local.sh` and `cluster_destroy_local.sh` use the short host name of the head node for the cluster name and as the base name (`$OS_PREFIX`) for the OpenStack resources which they create/destroy
- By default both `cluster_create_local.sh` and `cluster_destroy_local.sh` assume that the `openrc.sh` file lives in the user's home directory (`~/openrc.sh`) instead of the current directory
- Because `cluster_create_local.sh` assumes that it's running on a head node that already exists, it:
  - Does not create a new server to act as the cluster head node
  - Does not create a new floating IP address, nor attaches it to the head node
  - Drops the `HEADNODE_SIZE` flag
  - Looks up the OpenStack instance UUID for the current instance using the OpenStack metadata service and uses that for any OpenStack operations involving the head node
  - Mounts the (optional) storage volume to the current instance
  - Runs `install_local.sh` on the current instance
  - Installs the OpenStack command line tools
  - Generates a new SSH key on the head node, and uses that to create a new OpenStack SSH public key (`${OS_PREFIX}-elastic-key`), instead of looking for an existing SSH key
  - Instead of creating a temporary OpenStack application credential for Slurm to launch compute nodes and a new `openrc.sh` file to be copied to a new head node, it re-uses the credentials provided in the main `openrc.sh` file (Note: Exosphere generates this `openrc.sh` file from the same application credential that it uses when communicating with OpenStack, and injects it into a new head node at launch time using cloud-init)
- Because `cluster_destroy_local.sh` assumes that it's running on a head node that already exists, it:
  - Does not detach a floating IP address from the head node, nor deletes it (Note: This will leave a floating IP address behind which will have to be cleaned up manually)
  - Does not delete a temporary app credential (because `cluster_create_local.sh` does not create one)
  - Deletes `${OS_PREFIX}-elastic-key` (because `cluster_create_local.sh` always generates a new SSH key pair on the head node instance, and creates a corresponding OpenStack SSH public key)

Note: These scripts are useful outside of the Exosphere client, and can be used from Horizon or any OpenStack client by adding the following snippet of shell script to the cloud-init of a new OpenStack instance:

```bash
su - centos -c "git clone --branch cluster-create-local --single-branch https://github.com/julianpistorius/CRI_Jetstream_Cluster.git; cd CRI_Jetstream_Cluster; ./cluster_create_local.sh"
```

To test this using Exosphere, go to https://exosphere.jetstream-cloud.org and follow these instructions: https://gitlab.com/exosphere/exosphere/-/merge_requests/587#how-to-test

Once this PR is merged we will change the Exosphere code to reference this repository instead of my fork, and the `main` branch instead of the `cluster-create-local` branch.