### PR TITLE
Remove conflicting Lmod package

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ if [[ ${docker_allow} == 0 ]]; then
   dnf -y remove containerd.io.x86_64 docker-ce.x86_64 docker-ce-cli.x86_64 docker-ce-rootless-extras.x86_64
 fi
 
-dnf -y install \
+dnf -y --allowerasing install \
         ohpc-slurm-server \
         vim \
         ansible \

--- a/install_local.sh
+++ b/install_local.sh
@@ -54,7 +54,7 @@ if [[ ${docker_allow} == 0 ]]; then
   dnf -y remove containerd.io.x86_64 docker-ce.x86_64 docker-ce-cli.x86_64 docker-ce-rootless-extras.x86_64
 fi
 
-dnf -y install \
+dnf -y --allowerasing install \
         ohpc-slurm-server \
         vim \
         ansible \


### PR DESCRIPTION
Jetstream2 featured images now include the Lmod package by default. This  causes an error when running the install.sh and install_local.sh scripts on an instance created from the featured Rocky 8 image. These scripts try to install the lmod-ohpc, which causes a conflict with the existing Lmod package. To avoid this problem we add --allowerasing to the dnf commands which install the lmod-ohpc package. This results in the offending Lmod package being uninstalled.

Fixes #8