### PR TITLE
Change Ansible os_server task's userdata parameter

### DIFF
--- a/compute_build_base_img.yml
+++ b/compute_build_base_img.yml
@@ -28,7 +28,7 @@
       flavor: "{{ compute_base_size }}"
       meta: { compute: "base" }
       auto_ip: "no"
-      user_data: |
+      userdata: |
         #cloud-config
         packages: []
         package_update: false


### PR DESCRIPTION
The Ansible playbook that creates the compute nodes' image calls `os_server`. As far back as 2.7, [Ansible docs](https://docs.ansible.com/ansible/2.9/modules/os_server_module.html#parameter-userdata) reference `userdata`, not `user_data`. In fact, [pages online as far back as 2017](https://groups.google.com/g/ansible-devel/c/mu1HsqXcqoU) mention `userdata`. 

At present, running these scripts on Jetstream2's Rocky Linux 8 image will result in an error:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (os_server) module: user_data. Supported parameters include: . . . (lots of output skipped here) userdata (more skipped output) . . . ."}
```