### PR TITLE
Fix scripts for Jetstream2

### DIFF
--- a/cluster_create_local.sh
+++ b/cluster_create_local.sh
@@ -47,8 +47,8 @@ while getopts ":jdhhelp:n:o:s:v:" opt; do
   esac
 done
 
-sudo pip3 install openstacksdk==0.61.0
-sudo pip3 install python-openstackclient
+sudo pip3 install openstacksdk==2.1.0
+sudo pip3 install python-openstackclient==6.5.0
 sudo ln -s /usr/local/bin/openstack /usr/bin/openstack
 
 if [[ ! -f ${openrc_path} ]]; then

--- a/compute_build_base_img.yml
+++ b/compute_build_base_img.yml
@@ -20,7 +20,7 @@
     os_server:
       timeout: 300
       state: present
-      name: "compute-{{ ansible_facts.hostname }}-base-instance"
+      name: "{{ ansible_facts.hostname }}-compute-base-instance"
       cloud: "{{ openstack_cloud }}"
       image: "{{ compute_base_image }}"
       key_name: "{{ JS_ssh_keyname }}"

--- a/compute_build_base_img.yml
+++ b/compute_build_base_img.yml
@@ -44,9 +44,9 @@
 
   - name: add compute instance to inventory
     add_host:
-      name: "{{ os_host['openstack']['name'] }}"
+      name: "{{ os_host['server']['name'] }}"
       groups: "compute-base"
-      ansible_host: "{{ os_host.openstack.private_v4 }}"
+      ansible_host: "{{ os_host['server']['hostname'] }}"
 
   - name: pause for ssh to come up
     pause:

--- a/compute_take_snapshot.sh
+++ b/compute_take_snapshot.sh
@@ -3,7 +3,7 @@
 source /etc/slurm/openrc.sh
 
 compute_image="$(hostname -s)-compute-image-latest"
-compute_instance="compute-$(hostname -s)-base-instance"
+compute_instance="$(hostname -s)-compute-base-instance"
 
 openstack server stop ${compute_instance}
 

--- a/install_local.sh
+++ b/install_local.sh
@@ -75,8 +75,8 @@ pip3 install ansible
 mkdir -p /etc/ansible
 ln -s /usr/local/bin/ansible-playbook /usr/bin/ansible-playbook
 
-pip3 install openstacksdk==0.61.0
-pip3 install python-openstackclient==5.8.0
+sudo pip3 install openstacksdk==2.1.0
+sudo pip3 install python-openstackclient==6.5.0
 
 dnf -y update  # until the base python2-openstackclient install works out of the box!
 

--- a/ssh.cfg
+++ b/ssh.cfg
@@ -5,6 +5,13 @@ Host compute-*
  UserKnownHostsFile=/dev/null
  IdentityFile /etc/slurm/.ssh/slurm-key
 
+Host compute-*-base-instance
+ User rocky
+ StrictHostKeyChecking no
+ BatchMode yes
+ UserKnownHostsFile=/dev/null
+ IdentityFile /etc/slurm/.ssh/slurm-key
+
 Host 10.0.0.*
  User rocky
  StrictHostKeyChecking no

--- a/ssh.cfg
+++ b/ssh.cfg
@@ -5,13 +5,6 @@ Host compute-*
  UserKnownHostsFile=/dev/null
  IdentityFile /etc/slurm/.ssh/slurm-key
 
-Host compute-*-base-instance
- User rocky
- StrictHostKeyChecking no
- BatchMode yes
- UserKnownHostsFile=/dev/null
- IdentityFile /etc/slurm/.ssh/slurm-key
-
 Host 10.0.0.*
  User rocky
  StrictHostKeyChecking no

--- a/ssh.cfg
+++ b/ssh.cfg
@@ -1,4 +1,4 @@
-Host dimuthu-vc-compute-*
+Host compute-*
  User rocky
  StrictHostKeyChecking no
  BatchMode yes


### PR DESCRIPTION
At present, the `rocky-linux` branch fails setup on Jetstream2 (e.g. through Exosphere) due to relying on old versions of the OpenStack API. This PR introduces a couple of changes that allow it to function again:

1. Bumps `openstacksdk` and `python-openstackclient` up to the latest versions
2. Fixes resulting broken syntax on the Ansible return. There is no convenient way to get the IPv4 address of the created instance without hardcoding the network name (or using a janky fix, like taking the first network in the list), but we can use the hostname (`access_ipv4` returns null).
3. Changes the name of the image build instance to be more consistent with the other compute nodes' naming scheme (`${cluster-name}-compute-...`).
4. Removes what looks like an accidental hard-code of a cluster prefix from ssh.cfg

## To Test

1. Enable experimental features in Exosphere
2. Create a new Jetstream2 instance from the Featured-RockyLinux8 image (through Exosphere)
3. Set `Create your own SLURM cluster with this instance as the head node` to `Yes`
4. In the Boot Script, replace `{create-cluster-command}` with:
```
su - rocky -c "git clone --branch rocky-linux --single-branch --depth 1 https://github.com/zacharygraber/Jetstream_Cluster.git; cd Jetstream_Cluster; ./cluster_create_local.sh -d 2>&1 | tee local_create.log"
```

5. Once setup finishes, verify that you can run Slurm jobs:
```
sudo su - rocky
cd Jetstream_Cluster
sbatch ./slurm_test.job
```
